### PR TITLE
Updated ROS2 property names for time message

### DIFF
--- a/RBSManager/Classes/Messages/Standard/TImeMessage.swift
+++ b/RBSManager/Classes/Messages/Standard/TImeMessage.swift
@@ -21,8 +21,8 @@ public class TimeMessage: RBSMessage {
     }
     
     override public func mapping(map: Map) {
-        sec <- map["secs"]
-        nsec <- map["nsecs"]
+        sec <- map["sec"]
+        nsec <- map["nsec"]
     }
     
     public func date() -> Date {


### PR DESCRIPTION
ROS2 uses 'sec' and 'nosec' instead of the plural forms.